### PR TITLE
Compatibility tweaks for Python 2.x and non-Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,21 @@
 
 The BBC are planning on removing over 11,000 recipes from their website. This scraper will create a local repository of those recipes on your computer.
 
-Warning: This script will create a folder with over 11,000 html files in it.
+Warning: This script will create a folder with over 11,000 HTML files in it.
+
+## Instructions
+
+1. Install the dependencies:
+
+```python
+pip install beautifulsoup4
+pip install requests
+```
+
+2. Download the script and run it:
+
+```bash
+git clone https://github.com/Thomas-Rudge/BBC-Recipe-Web-Scraper.git
+cd BBC-Recipe-Web-Scraper
+python scrape_bbc_recipes.py
+```

--- a/scrape_bbc_recipes.py
+++ b/scrape_bbc_recipes.py
@@ -14,7 +14,7 @@
 #-------------------------------------------------------------------------------
 
 
-import bs4, os, requests, time
+import bs4, os, requests, time, io
 
 
 def get_sitemap():
@@ -52,13 +52,13 @@ def make_repodir():
     Make the repositories where the html and css files will be stored
     '''
     ## Create the location where the CSS will be stored
-    cwd = os.getcwd()
+    cwd = os.getcwd() + os.sep
 
     try:
-        if not os.path.isdir(cwd + '\\BBC_Food_Repo'):
-            os.mkdir(cwd + '\\BBC_Food_Repo')
-        if not os.path.isdir(cwd + '\\BBC_Food_Repo\\css'):
-            os.mkdir(cwd + '\\BBC_Food_Repo\\css')
+        if not os.path.isdir(cwd + 'BBC_Food_Repo'):
+            os.mkdir(cwd + 'BBC_Food_Repo')
+        if not os.path.isdir(cwd + 'BBC_Food_Repo' + os.sep + 'css'):
+            os.mkdir(cwd + 'BBC_Food_Repo' + os.sep + 'css')
     except Exception as e:
         raise Exception(str(e))
 
@@ -105,7 +105,7 @@ def get_stylesheets():
         except requests.RequestException:
             continue
 
-        with open('BBC_Food_Repo\\css\\' + link.split('/')[-1], 'w', encoding='utf-8') as css:
+        with io.open('BBC_Food_Repo' + os.sep + 'css' + os.sep + link.split('/')[-1], 'w', encoding='utf-8') as css:
             css.write(sheet.text)
 
     return sheets
@@ -118,8 +118,9 @@ def save_pages(css_links):
     '''
     cwd = os.getcwd()
     ## Build the new header data
+    sep = os.sep
     for i, link in enumerate(css_links):
-        css_links[i] = cwd + '\\BBC_Food_Repo\\css\\' + link.split('/')[-1]
+        css_links[i] = cwd + sep + 'BBC_Food_Repo' + sep + 'css' + sep + link.split('/')[-1]
 
     ## Cycle through the sitemap grabbing each recipe
     with open('bbc_sitemap.txt', 'r') as f:
@@ -180,19 +181,15 @@ def save_pages(css_links):
             ## Convert the soup back into html and save it to file
             html = soup.prettify()
 
-            with open('BBC_Food_Repo/' + line.split('/')[-1] + '.html', 'w', encoding='utf-8-sig') as html_page:
+            with io.open('BBC_Food_Repo/' + line.split('/')[-1] + '.html', 'w', encoding='utf-8-sig') as html_page:
                 html_page.write(html)
 
 
 def main():
     get_sitemap()
-
     make_repodir()
-
     stylesheets = get_stylesheets()
-
     save_pages(stylesheets)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
These are the minimal changes necessary to make this run on Python 2.x and an OS which doesn't use \\ for directory separators.